### PR TITLE
Ch03: fix typo and perf tldr install

### DIFF
--- a/docs/Ch03/index.md
+++ b/docs/Ch03/index.md
@@ -29,7 +29,7 @@
 
     在其他的发行版上，如果没有预装好的应用商店，可以安装 [Snapcraft](https://snapcraft.io/) 或 [Flatpak](https://flatpak.org/) 等在不同发行版上通用的应用商店。（注意：Snap 商店在国内的访问速度较慢。）
 
-### 使用包管系统安装 {#use-package-management-system}
+### 使用包管理系统安装 {#use-package-management-system}
 
 软件包管理器是一系列工具的集合，它自动化地完成软件的安装、更新、配置和移除功能。
 
@@ -41,7 +41,7 @@
 
 但是与应用商店相比，使用包管理器安装需要预先知道所需软件在软件仓库中的对应包名，和应用商店相比无法进行模糊搜索（不过你也可以在包管理器官网上进行查找包名，再通过包管理器安装）。
 
-包管理系统有很多，比如管理 Debian (.deb) 软件包的 `dpkg` 以及它的前端 `apt`（用于 Debian 系的发行版）；`rpm` 包管理器以及它的前端 `dnf`（用于 Fedora 和新版的 CentOS 和 RHEL）、前端 `yum`（用于 CentOS 7 和 RHEL 7 等）；Pacman 包管理器（用于 Arch Linux 和 Manjaro）等等。
+包管理系统有很多，比如管理 Debian (.deb) 软件包的 `dpkg` 以及它的前端 `apt`（用于 Debian 系的发行版）；`rpm` 包管理器以及它的前端 `dnf`（用于 Fedora 和新版的 CentOS 和 RHEL）、前端 `yum`（用于 CentOS 7 和 RHEL 7 等）；`Pacman` 包管理器（用于 Arch Linux 和 Manjaro）等等。
 
 **为了方便讲述，本章下文中我们都将以 apt 作为典型实例进行讲解。**
 
@@ -964,6 +964,8 @@ DESCRIPTION
 
 ```shell
 $ sudo apt install tldr
+$ # 更新 tldr pages
+$ tldr -u
 ```
 
 #### 使用 {#use-tldr}

--- a/docs/Ch03/index.md
+++ b/docs/Ch03/index.md
@@ -41,7 +41,7 @@
 
 但是与应用商店相比，使用包管理器安装需要预先知道所需软件在软件仓库中的对应包名，和应用商店相比无法进行模糊搜索（不过你也可以在包管理器官网上进行查找包名，再通过包管理器安装）。
 
-包管理系统有很多，比如管理 Debian (.deb) 软件包的 `dpkg` 以及它的前端 `apt`（用于 Debian 系的发行版）；`rpm` 包管理器以及它的前端 `dnf`（用于 Fedora 和新版的 CentOS 和 RHEL）、前端 `yum`（用于 CentOS 7 和 RHEL 7 等）；`Pacman` 包管理器（用于 Arch Linux 和 Manjaro）等等。
+包管理系统有很多，比如管理 Debian (.deb) 软件包的 `dpkg` 以及它的前端 `apt`（用于 Debian 系的发行版）；`rpm` 包管理器以及它的前端 `dnf`（用于 Fedora 和新版的 CentOS 和 RHEL）、前端 `yum`（用于 CentOS 7 和 RHEL 7 等）；`pacman` 包管理器（用于 Arch Linux 和 Manjaro）等等。
 
 **为了方便讲述，本章下文中我们都将以 apt 作为典型实例进行讲解。**
 
@@ -965,7 +965,7 @@ DESCRIPTION
 ```shell
 $ sudo apt install tldr
 $ # 更新 tldr pages
-$ tldr -u
+$ tldr --update
 ```
 
 #### 使用 {#use-tldr}


### PR DESCRIPTION
使用 ubuntu 实测 apt 下载的 tldr，发现其并没有包含数据，所以在 install 中加入了 `tldr -u` 以更新。